### PR TITLE
Feat FullScreen Button

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,0 +1,28 @@
+import PropTypes from 'prop-types';
+import clsx from 'clsx'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import React, { useState } from 'react'
+
+import './Button.scss'
+
+const propTypes = {
+    type: PropTypes.string,
+    onClick: PropTypes.function,
+}
+
+const renderFullScreenIncon = (state) => {
+    return state === false
+        ? <FontAwesomeIcon icon="expand-arrows-alt" aria-label="expand fullscreen" />
+        : <FontAwesomeIcon icon="times-circle" aria-label="exit fullscreen" />
+}
+export default function Button({ type, onClick }) {
+    const [fullScreen, setFullScreen] = useState(false)
+
+    return <div className="button" onClick={() => setFullScreen(prop => !prop)}>
+        <div className={clsx({ 'button__expandFullScreen': !fullScreen, 'button__exitFullScreen': fullScreen, })}>
+            <i className="button__icon">{renderFullScreenIncon(fullScreen)}</i>
+        </div>
+    </div>
+}
+
+Button.propTypes = propTypes

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,27 +1,46 @@
 import PropTypes from 'prop-types';
 import clsx from 'clsx'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import React, { useState } from 'react'
+import React from 'react'
 
+import { FULLSCREEN } from '../../global/reserved';
 import './Button.scss'
 
 const propTypes = {
-    type: PropTypes.string,
     state: PropTypes.bool,
+    type: PropTypes.string,
     onClick: PropTypes.function,
 }
 
-const renderFullScreenIncon = (state) => {
-    return state === false
+const renderFullScreenIcon = (state) => {
+    const selectIcon = state === false
         ? <FontAwesomeIcon icon="expand-arrows-alt" aria-label="expand fullscreen" />
         : <FontAwesomeIcon icon="times-circle" aria-label="exit fullscreen" />
+    return <i className="button__icon">{selectIcon}</i>
 }
-export default function Button({ type, state, setState }) {
-    return <div className="button" onClick={() => setState(prop => !prop)}>
-        <div className={clsx({ 'button__expandFullScreen': !state, 'button__exitFullScreen': state, })}>
-            <i className="button__icon">{renderFullScreenIncon(state)}</i>
-        </div>
-    </div>
+
+function renderTitle(state) {
+    return state === false ? 'Press to Full Screen' : 'Press to Exit Full Screen'
+}
+
+export default function Button({ type, state, onClick }) {
+    const ICON = {
+        [FULLSCREEN]: renderFullScreenIcon(state)
+    }
+    const TITLE = {
+        [FULLSCREEN]: renderTitle(state)
+    }
+    const BUTTONCLASSNAME = {
+        [FULLSCREEN]: clsx({ 'button__expandFullScreen': !state, 'button__exitFullScreen': state })
+    }
+
+    return (
+        <div className="button__container" onClick={onClick}>
+            <button className={BUTTONCLASSNAME[type]} title={TITLE[type]} type="button">
+                {ICON[type]}
+            </button>
+        </div >
+    )
 }
 
 Button.propTypes = propTypes

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -7,6 +7,7 @@ import './Button.scss'
 
 const propTypes = {
     type: PropTypes.string,
+    state: PropTypes.bool,
     onClick: PropTypes.function,
 }
 
@@ -15,12 +16,10 @@ const renderFullScreenIncon = (state) => {
         ? <FontAwesomeIcon icon="expand-arrows-alt" aria-label="expand fullscreen" />
         : <FontAwesomeIcon icon="times-circle" aria-label="exit fullscreen" />
 }
-export default function Button({ type, onClick }) {
-    const [fullScreen, setFullScreen] = useState(false)
-
-    return <div className="button" onClick={() => setFullScreen(prop => !prop)}>
-        <div className={clsx({ 'button__expandFullScreen': !fullScreen, 'button__exitFullScreen': fullScreen, })}>
-            <i className="button__icon">{renderFullScreenIncon(fullScreen)}</i>
+export default function Button({ type, state, setState }) {
+    return <div className="button" onClick={() => setState(prop => !prop)}>
+        <div className={clsx({ 'button__expandFullScreen': !state, 'button__exitFullScreen': state, })}>
+            <i className="button__icon">{renderFullScreenIncon(state)}</i>
         </div>
     </div>
 }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -1,0 +1,23 @@
+@import '_variables';
+
+.button {
+    display: flex;
+    flex-direction: row-reverse;
+
+    &__expandFullScreen:hover{
+        color:$logo-blue;
+    }
+
+    &__exitFullScreen:hover{
+        color:$logo-blue
+    }
+
+}
+
+.button__icon {
+    height: 2em;
+    width: 2em;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -1,11 +1,33 @@
 @import '_variables';
 
-.button {
+button, input[type="button"] {
+    background: none;
+    color: inherit;
+    outline: none;
+    border: 0;
+	padding: 0;
+	cursor: pointer;
+    font: inherit;
+
+    //WIP: there is a border when pressed
+    &:active, :focus{
+        border: 0;
+    }
+}
+
+button, input[type="button"]::-moz-focus-inner {
+   border: 0;
+}
+
+.button__container{
     display: flex;
     flex-direction: row-reverse;
+}
 
+.button {
     &__expandFullScreen:hover{
             color:$logo-blue;
+
     }
 
     &__exitFullScreen:hover{

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -5,7 +5,7 @@
     flex-direction: row-reverse;
 
     &__expandFullScreen:hover{
-        color:$logo-blue;
+            color:$logo-blue;
     }
 
     &__exitFullScreen:hover{
@@ -15,8 +15,7 @@
 }
 
 .button__icon {
-    height: 2em;
-    width: 2em;
+    padding: .5em;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -1,6 +1,6 @@
 import React from 'react'
-
 import Button from 'components/Button/Button';
+import { FULLSCREEN } from '../../global/reserved';
 
 export default {
     title: 'Components/Button/Button',
@@ -16,4 +16,4 @@ const Template = (args) => (<Button {...args} />)
 
 export const FullScreen = Template.bind({})
 
-FullScreen.args = { type: 'FullScreen', };
+FullScreen.args = { type: FULLSCREEN, state: true };

--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+import Button from 'components/Button/Button';
+
+export default {
+    title: 'Components/Button/Button',
+    component: Button,
+    parameters: {
+        actions: {
+            handles: ['mouseover', 'click']
+        }
+    }
+}
+
+const Template = (args) => (<Button {...args} />)
+
+export const FullScreen = Template.bind({})
+
+FullScreen.args = { type: 'FullScreen', };

--- a/src/components/Table/Simple.js
+++ b/src/components/Table/Simple.js
@@ -1,7 +1,9 @@
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import {useExpanded, useSortBy, useTable} from 'react-table';
-import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import { useExpanded, useSortBy, useTable } from 'react-table';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import Button from '../Button/Button'
 
 import './Simple.scss';
 
@@ -20,7 +22,7 @@ const propTypes = {
  *
  * This supports: sorting, expanding
  */
-export default function SimpleTable({tableProps = {}, columns = [], data, expandable = false, className}) {
+export default function SimpleTable({ tableProps = {}, columns = [], data, expandable = false, className }) {
   const renderExpansionIcon = (expanded) => {
     if (expanded) {
       return <FontAwesomeIcon icon="chevron-right" className="simpleTable__expansion--rotateOpen" />;
@@ -33,7 +35,7 @@ export default function SimpleTable({tableProps = {}, columns = [], data, expand
       columns.unshift({
         id: 'expander',
         // eslint-disable-next-line react/prop-types
-        Cell: ({row}) => {
+        Cell: ({ row }) => {
           // use the row.canExpand and row.getToggleRowExpandedProps prop getter to build the toggle for expanding a row
           // eslint-disable-next-line react/prop-types
           if (row.canExpand) {
@@ -58,7 +60,7 @@ export default function SimpleTable({tableProps = {}, columns = [], data, expand
           return null;
         },
         // eslint-disable-next-line react/prop-types
-        Header: ({getToggleAllRowsExpandedProps, isAllRowsExpanded}) => (
+        Header: ({ getToggleAllRowsExpandedProps, isAllRowsExpanded }) => (
           <span {...getToggleAllRowsExpandedProps()}>
             {renderExpansionIcon(isAllRowsExpanded)}
           </span>
@@ -74,7 +76,7 @@ export default function SimpleTable({tableProps = {}, columns = [], data, expand
     headerGroups, // headerGroups if your table have groupings
     rows, // rows for the table based on the data passed
     prepareRow, // Prepare the row (this function need to called for each row before getting the row props)
-  } = useTable({columns, data, ...tableProps}, useSortBy, useExpanded);
+  } = useTable({ columns, data, ...tableProps }, useSortBy, useExpanded);
 
   const renderSortIcon = (col) => {
     if (col.sortable) {
@@ -91,58 +93,61 @@ export default function SimpleTable({tableProps = {}, columns = [], data, expand
   };
 
   return (
-    <table {...getTableProps()} className={clsx('simpleTable', className)}>
-      <thead>{
-        headerGroups.map((headerGroup, hdrIdx) => {
-          const isGroup = headerGroups.length > 1 && hdrIdx !== headerGroups.length - 1;
-          return (
-            <tr {...headerGroup.getHeaderGroupProps()} className={clsx({simpleTable__group: isGroup})}>
-              {headerGroup.headers.map((column, idx) => {
-                const addBorder = idx > 0 && isGroup;
-                const headerProps = column.sortable ? column.getSortByToggleProps() : {};
-                headerProps.className = clsx(column.className, {
-                  'simpleTable__group--border': addBorder,
-                });
-                headerProps.style = column.style;
-                return (
-                  <th {...column.getHeaderProps(headerProps)}>
-                    {column.render('Header')}
-                    {renderSortIcon(column)}
-                  </th>
-                );
-              })}
-            </tr>
-          );
-        })
-      }
-      </thead>
-      <tbody {...getTableBodyProps()}>{
-        rows.map((row) => {
-          prepareRow(row);
-          return (
-            // eslint-disable-next-line react/prop-types
-            <tr {...row.getRowProps()}>
-              {
-                // eslint-disable-next-line react/prop-types
-                row.cells.map((cell) => (
-                  <td
-                    {...cell.getCellProps([
-                      {
-                        className: cell.column.className,
-                        style: cell.column.style,
-                      },
-                    ])}
-                  >
-                    {cell.render('Cell')}
-                  </td>
-                ))
-              }
-            </tr>
-          );
-        })
-      }
-      </tbody>
-    </table>
+    <>
+      <Button type="fullScreen" />
+      <table {...getTableProps()} className={clsx('simpleTable', className)}>
+        <thead>{
+          headerGroups.map((headerGroup, hdrIdx) => {
+            const isGroup = headerGroups.length > 1 && hdrIdx !== headerGroups.length - 1;
+            return (
+              <tr {...headerGroup.getHeaderGroupProps()} className={clsx({ simpleTable__group: isGroup })}>
+                {headerGroup.headers.map((column, idx) => {
+                  const addBorder = idx > 0 && isGroup;
+                  const headerProps = column.sortable ? column.getSortByToggleProps() : {};
+                  headerProps.className = clsx(column.className, {
+                    'simpleTable__group--border': addBorder,
+                  });
+                  headerProps.style = column.style;
+                  return (
+                    <th {...column.getHeaderProps(headerProps)}>
+                      {column.render('Header')}
+                      {renderSortIcon(column)}
+                    </th>
+                  );
+                })}
+              </tr>
+            );
+          })
+        }
+        </thead>
+        <tbody {...getTableBodyProps()}>{
+          rows.map((row) => {
+            prepareRow(row);
+            return (
+              // eslint-disable-next-line react/prop-types
+              <tr {...row.getRowProps()}>
+                {
+                  // eslint-disable-next-line react/prop-types
+                  row.cells.map((cell) => (
+                    <td
+                      {...cell.getCellProps([
+                        {
+                          className: cell.column.className,
+                          style: cell.column.style,
+                        },
+                      ])}
+                    >
+                      {cell.render('Cell')}
+                    </td>
+                  ))
+                }
+              </tr>
+            );
+          })
+        }
+        </tbody>
+      </table>
+    </>
   );
 }
 

--- a/src/components/Table/Simple.js
+++ b/src/components/Table/Simple.js
@@ -1,3 +1,4 @@
+import React, { useState } from 'react'
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { useExpanded, useSortBy, useTable } from 'react-table';
@@ -23,6 +24,7 @@ const propTypes = {
  * This supports: sorting, expanding
  */
 export default function SimpleTable({ tableProps = {}, columns = [], data, expandable = false, className }) {
+  const [fullscreen, setFullScreen] = useState(false)
   const renderExpansionIcon = (expanded) => {
     if (expanded) {
       return <FontAwesomeIcon icon="chevron-right" className="simpleTable__expansion--rotateOpen" />;
@@ -93,61 +95,66 @@ export default function SimpleTable({ tableProps = {}, columns = [], data, expan
   };
 
   return (
-    <>
-      <Button type="fullScreen" />
-      <table {...getTableProps()} className={clsx('simpleTable', className)}>
-        <thead>{
-          headerGroups.map((headerGroup, hdrIdx) => {
-            const isGroup = headerGroups.length > 1 && hdrIdx !== headerGroups.length - 1;
-            return (
-              <tr {...headerGroup.getHeaderGroupProps()} className={clsx({ simpleTable__group: isGroup })}>
-                {headerGroup.headers.map((column, idx) => {
-                  const addBorder = idx > 0 && isGroup;
-                  const headerProps = column.sortable ? column.getSortByToggleProps() : {};
-                  headerProps.className = clsx(column.className, {
-                    'simpleTable__group--border': addBorder,
-                  });
-                  headerProps.style = column.style;
-                  return (
-                    <th {...column.getHeaderProps(headerProps)}>
-                      {column.render('Header')}
-                      {renderSortIcon(column)}
-                    </th>
-                  );
-                })}
-              </tr>
-            );
-          })
-        }
-        </thead>
-        <tbody {...getTableBodyProps()}>{
-          rows.map((row) => {
-            prepareRow(row);
-            return (
-              // eslint-disable-next-line react/prop-types
-              <tr {...row.getRowProps()}>
-                {
-                  // eslint-disable-next-line react/prop-types
-                  row.cells.map((cell) => (
-                    <td
-                      {...cell.getCellProps([
-                        {
-                          className: cell.column.className,
-                          style: cell.column.style,
-                        },
-                      ])}
-                    >
-                      {cell.render('Cell')}
-                    </td>
-                  ))
-                }
-              </tr>
-            );
-          })
-        }
-        </tbody>
-      </table>
-    </>
+    <div className="test0">
+      <div className="test">hello</div>
+      <div className={clsx({ 'simpleTable__container': !fullscreen, 'simpleTable__container--fullscreen': fullscreen })}>
+        <div className="simpleTable__button--container">
+          <Button type="fullScreen" state={fullscreen} setState={setFullScreen} />
+        </div>
+        <table {...getTableProps()} className={clsx('simpleTable', className)}>
+          <thead>{
+            headerGroups.map((headerGroup, hdrIdx) => {
+              const isGroup = headerGroups.length > 1 && hdrIdx !== headerGroups.length - 1;
+              return (
+                <tr {...headerGroup.getHeaderGroupProps()} className={clsx({ simpleTable__group: isGroup })}>
+                  {headerGroup.headers.map((column, idx) => {
+                    const addBorder = idx > 0 && isGroup;
+                    const headerProps = column.sortable ? column.getSortByToggleProps() : {};
+                    headerProps.className = clsx(column.className, {
+                      'simpleTable__group--border': addBorder,
+                    });
+                    headerProps.style = column.style;
+                    return (
+                      <th {...column.getHeaderProps(headerProps)}>
+                        {column.render('Header')}
+                        {renderSortIcon(column)}
+                      </th>
+                    );
+                  })}
+                </tr>
+              );
+            })
+          }
+          </thead>
+          <tbody {...getTableBodyProps()}>{
+            rows.map((row) => {
+              prepareRow(row);
+              return (
+                // eslint-disable-next-line react/prop-types
+                <tr {...row.getRowProps()}>
+                  {
+                    // eslint-disable-next-line react/prop-types
+                    row.cells.map((cell) => (
+                      <td
+                        {...cell.getCellProps([
+                          {
+                            className: cell.column.className,
+                            style: cell.column.style,
+                          },
+                        ])}
+                      >
+                        {cell.render('Cell')}
+                      </td>
+                    ))
+                  }
+                </tr>
+              );
+            })
+          }
+          </tbody>
+        </table>
+      </div>
+    </div>
   );
 }
 

--- a/src/components/Table/Simple.js
+++ b/src/components/Table/Simple.js
@@ -4,8 +4,8 @@ import clsx from 'clsx';
 import { useExpanded, useSortBy, useTable } from 'react-table';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
+import { FULLSCREEN } from '../../global/reserved';
 import Button from '../Button/Button'
-
 import './Simple.scss';
 
 const propTypes = {
@@ -94,10 +94,11 @@ export default function SimpleTable({ tableProps = {}, columns = [], data, expan
     return '';
   };
 
+
   return (
     <div className={clsx({ 'simpleTable__container': !fullscreen, 'simpleTable__container--fullscreen': fullscreen })}>
       <div className="simpleTable__button--container">
-        <Button type="fullScreen" state={fullscreen} setState={setFullScreen} />
+        <Button type={FULLSCREEN} state={fullscreen} onClick={() => setFullScreen(props => !props)} />
       </div>
       <table {...getTableProps()} className={clsx('simpleTable', className)}>
         <thead>{

--- a/src/components/Table/Simple.js
+++ b/src/components/Table/Simple.js
@@ -95,65 +95,62 @@ export default function SimpleTable({ tableProps = {}, columns = [], data, expan
   };
 
   return (
-    <div className="test0">
-      <div className="test">hello</div>
-      <div className={clsx({ 'simpleTable__container': !fullscreen, 'simpleTable__container--fullscreen': fullscreen })}>
-        <div className="simpleTable__button--container">
-          <Button type="fullScreen" state={fullscreen} setState={setFullScreen} />
-        </div>
-        <table {...getTableProps()} className={clsx('simpleTable', className)}>
-          <thead>{
-            headerGroups.map((headerGroup, hdrIdx) => {
-              const isGroup = headerGroups.length > 1 && hdrIdx !== headerGroups.length - 1;
-              return (
-                <tr {...headerGroup.getHeaderGroupProps()} className={clsx({ simpleTable__group: isGroup })}>
-                  {headerGroup.headers.map((column, idx) => {
-                    const addBorder = idx > 0 && isGroup;
-                    const headerProps = column.sortable ? column.getSortByToggleProps() : {};
-                    headerProps.className = clsx(column.className, {
-                      'simpleTable__group--border': addBorder,
-                    });
-                    headerProps.style = column.style;
-                    return (
-                      <th {...column.getHeaderProps(headerProps)}>
-                        {column.render('Header')}
-                        {renderSortIcon(column)}
-                      </th>
-                    );
-                  })}
-                </tr>
-              );
-            })
-          }
-          </thead>
-          <tbody {...getTableBodyProps()}>{
-            rows.map((row) => {
-              prepareRow(row);
-              return (
-                // eslint-disable-next-line react/prop-types
-                <tr {...row.getRowProps()}>
-                  {
-                    // eslint-disable-next-line react/prop-types
-                    row.cells.map((cell) => (
-                      <td
-                        {...cell.getCellProps([
-                          {
-                            className: cell.column.className,
-                            style: cell.column.style,
-                          },
-                        ])}
-                      >
-                        {cell.render('Cell')}
-                      </td>
-                    ))
-                  }
-                </tr>
-              );
-            })
-          }
-          </tbody>
-        </table>
+    <div className={clsx({ 'simpleTable__container': !fullscreen, 'simpleTable__container--fullscreen': fullscreen })}>
+      <div className="simpleTable__button--container">
+        <Button type="fullScreen" state={fullscreen} setState={setFullScreen} />
       </div>
+      <table {...getTableProps()} className={clsx('simpleTable', className)}>
+        <thead>{
+          headerGroups.map((headerGroup, hdrIdx) => {
+            const isGroup = headerGroups.length > 1 && hdrIdx !== headerGroups.length - 1;
+            return (
+              <tr {...headerGroup.getHeaderGroupProps()} className={clsx({ simpleTable__group: isGroup })}>
+                {headerGroup.headers.map((column, idx) => {
+                  const addBorder = idx > 0 && isGroup;
+                  const headerProps = column.sortable ? column.getSortByToggleProps() : {};
+                  headerProps.className = clsx(column.className, {
+                    'simpleTable__group--border': addBorder,
+                  });
+                  headerProps.style = column.style;
+                  return (
+                    <th {...column.getHeaderProps(headerProps)}>
+                      {column.render('Header')}
+                      {renderSortIcon(column)}
+                    </th>
+                  );
+                })}
+              </tr>
+            );
+          })
+        }
+        </thead>
+        <tbody {...getTableBodyProps()}>{
+          rows.map((row) => {
+            prepareRow(row);
+            return (
+              // eslint-disable-next-line react/prop-types
+              <tr {...row.getRowProps()}>
+                {
+                  // eslint-disable-next-line react/prop-types
+                  row.cells.map((cell) => (
+                    <td
+                      {...cell.getCellProps([
+                        {
+                          className: cell.column.className,
+                          style: cell.column.style,
+                        },
+                      ])}
+                    >
+                      {cell.render('Cell')}
+                    </td>
+                  ))
+                }
+              </tr>
+            );
+          })
+        }
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/src/components/Table/Simple.scss
+++ b/src/components/Table/Simple.scss
@@ -1,45 +1,28 @@
 @import '_variables';
 
-.test0{
-  width: 600px;
-  margin-left: 200px;
-}
-.test {
-  height: 200px;
-}
 .simpleTable__container{
+    background-color: $white;
     width: inherit;
     height: inherit;
 
     transition: 
-      width .2s ease-out,
-      height .2s ease-out;
+      width .4s ease-out,
+      height .3s ease-out;
 
   &--fullscreen{
+    background-color: $white;
     display: flex;
     flex-direction: column;
     position: absolute;
-    top:0;
-    left:0;
+    top:0%;
+    left:0%;
     width: 100vw;
     height: 100vh;
     max-width: 100%; //100vw includes scrollbar area, this deals with it
 
     transition: 
-      width .5s ease-out,
-      height .5s ease-out;
-      
-    //animation: 10s linear expand;
-  }
-
-  //WIP: I think we need to use keyframes
-  @keyframes expand {
-    to{
-
-    } 
-    from {
-
-    }
+      width .4s ease-out,
+      height .3s ease-out,
   }
 }
 

--- a/src/components/Table/Simple.scss
+++ b/src/components/Table/Simple.scss
@@ -1,5 +1,48 @@
 @import '_variables';
 
+.test0{
+  width: 600px;
+  margin-left: 200px;
+}
+.test {
+  height: 200px;
+}
+.simpleTable__container{
+    width: inherit;
+    height: inherit;
+
+    transition: 
+      width .2s ease-out,
+      height .2s ease-out;
+
+  &--fullscreen{
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+    top:0;
+    left:0;
+    width: 100vw;
+    height: 100vh;
+    max-width: 100%; //100vw includes scrollbar area, this deals with it
+
+    transition: 
+      width .5s ease-out,
+      height .5s ease-out;
+      
+    //animation: 10s linear expand;
+  }
+
+  //WIP: I think we need to use keyframes
+  @keyframes expand {
+    to{
+
+    } 
+    from {
+
+    }
+  }
+}
+
 .simpleTable {
   &__expansion {
     width: 3em;

--- a/src/components/Table/Simple.stories.js
+++ b/src/components/Table/Simple.stories.js
@@ -177,7 +177,7 @@ const data = [
   },
 ];
 
-const defaultCols = [{...firstNameCol}, {...lastNameCol}, {...ageCol}];
+const defaultCols = [{ ...firstNameCol }, { ...lastNameCol }, { ...ageCol }];
 const defaultTemplate = (args) => (<SimpleTable {...args} />);
 
 export const Default = defaultTemplate.bind();
@@ -201,12 +201,12 @@ EvenHeaderGroup.args = {
     {
       id: 'name',
       Header: 'Name',
-      columns: [{...firstNameCol}, {...lastNameCol}],
+      columns: [{ ...firstNameCol }, { ...lastNameCol }],
     },
     {
       id: 'info',
       Header: 'Info',
-      columns: [{...ageCol}],
+      columns: [{ ...ageCol }],
     },
   ],
   data,
@@ -220,9 +220,9 @@ UnevenHeaderGroup.args = {
     {
       id: 'name',
       Header: 'Name',
-      columns: [{...firstNameCol}, {...lastNameCol}],
+      columns: [{ ...firstNameCol }, { ...lastNameCol }],
     },
-    {...ageCol},
+    { ...ageCol },
   ],
   data,
   expandable: true,

--- a/src/global/reserved.js
+++ b/src/global/reserved.js
@@ -1,0 +1,1 @@
+export const FULLSCREEN = 'fullscreen'

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,16 @@
-import {faChevronLeft} from '@fortawesome/free-solid-svg-icons/faChevronLeft';
-import {faChevronRight} from '@fortawesome/free-solid-svg-icons/faChevronRight';
-import {faSort} from '@fortawesome/free-solid-svg-icons/faSort';
-import {faSortDown} from '@fortawesome/free-solid-svg-icons/faSortDown';
-import {faSortUp} from '@fortawesome/free-solid-svg-icons/faSortUp';
+import { faChevronLeft } from '@fortawesome/free-solid-svg-icons/faChevronLeft';
+import { faChevronRight } from '@fortawesome/free-solid-svg-icons/faChevronRight';
+import { faSort } from '@fortawesome/free-solid-svg-icons/faSort';
+import { faSortDown } from '@fortawesome/free-solid-svg-icons/faSortDown';
+import { faSortUp } from '@fortawesome/free-solid-svg-icons/faSortUp';
 
-import {library} from '@fortawesome/fontawesome-svg-core';
+import { faExpandArrowsAlt } from '@fortawesome/free-solid-svg-icons/faExpandArrowsAlt';
+import { faTimesCircle } from '@fortawesome/free-solid-svg-icons/faTimesCircle';
+
+import { library } from '@fortawesome/fontawesome-svg-core';
 
 library.add(
   faChevronLeft, faChevronRight,
   faSort, faSortDown, faSortUp,
+  faExpandArrowsAlt, faTimesCircle,
 );


### PR DESCRIPTION

## What?
I've implement a seprate component Button that enables full screen of table component.

##Why?
Users want to view more of the table content without scrolling[Issue ticket](https://github.com/PharmGKB/component-incubator/issues/4#issue-740230089)

## How?
When user press the button, it triggers a state change change, and clcx renders the appropriate className for the parent container, With the help of css properties: { position: absolute; top: 0, left:0; width: 100vw; height: 100vh; max-width: 100% } the component is move to the top left of the screen, and expands to the viewport. A side-note: 100vw includes the area of scroll bar, so its necessary to use max-width:100% to prevent content being hidden by the scrollbar.

## Screenshots (optional)
0

## Anything Else?
It is troublesome to test this feature in storybook. I think we will need to export this component and test across each browser to make sure it correctly works.